### PR TITLE
Correct XDR listing for device ID.

### DIFF
--- a/BEPv1.md
+++ b/BEPv1.md
@@ -316,7 +316,7 @@ peers acting in a specific manner as a result of sent options.
     }
 
     struct Device {
-        string ID<>;
+        opaque ID<32>;
         unsigned int Flags;
         unsigned hyper MaxLocalVersion;
     }


### PR DESCRIPTION
According to the [reference implementation](https://github.com/syncthing/protocol/blob/442e93d3fc7728d7560c8d039a4199a77879b9f6/message.go#L107), device ID is sent as an opaque binary blob, not a UTF-8 encoded string.